### PR TITLE
Add auto delete from history and fixed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ app = Gigapixel(exe_path, output_suffix)
 
 # Process image.
 image = Path('path/to/image.jpg')
-output_path = app.process(image, scale=Scale.X2, mode=Mode.STANDARD)
+output_path = app.process(image, scale=Scale.X2, mode=Mode.STANDARD, delete_from_history=True)
 
 # Print output path.
 print(output_path)

--- a/gigapixel/gigapixel.py
+++ b/gigapixel/gigapixel.py
@@ -60,6 +60,10 @@ class Gigapixel:
             send_keys('^S {ENTER}')
             self._main_window.child_window(title="Cancel Processing", control_type="Button").wait_not('visible',
                                                                                                       timeout=60)
+        
+        @log("Deleting photo from history", "Photo deleted", level=Level.DEBUG)
+        def delete_photo(self) -> None:
+            self._main_window.Pane.Button2.click_input()
 
         @log("Setting processing options", "Processing options set", level=Level.DEBUG)
         def set_processing_options(self, scale: Optional[Scale] = None, mode: Optional[Mode] = None) -> None:
@@ -129,11 +133,13 @@ class Gigapixel:
 
     @log(start="Starting processing: {}", format=(1,))
     @log(end="Finished processing: {}", format=(1,), level=Level.SUCCESS)
-    def process(self, photo_path: Path, scale: Scale = Scale.X2, mode: Mode = Mode.STANDARD) -> Path:
+    def process(self, photo_path: Path, scale: Scale = Scale.X2, mode: Mode = Mode.STANDARD, delete_from_history: bool = True) -> Path:
         self._check_path(photo_path)
 
         self._app.open_photo(photo_path)
         self._app.set_processing_options(scale, mode)
         self._app.save_photo()
+        if delete_from_history:
+            self._app.delete_photo()
 
         return self._get_save_path(photo_path)

--- a/gigapixel/gigapixel.py
+++ b/gigapixel/gigapixel.py
@@ -60,7 +60,7 @@ class Gigapixel:
             send_keys('^S {ENTER}')
             self._main_window.child_window(title="Cancel Processing", control_type="Button").wait_not('visible',
                                                                                                       timeout=60)
-        
+
         @log("Deleting photo from history", "Photo deleted", level=Level.DEBUG)
         def delete_photo(self) -> None:
             self._main_window.Pane.Button2.click_input()

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,6 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/requirements_dev.txt
-commands =
-    pytest
 
 [testenv:flake8]
 basepython = python3.10


### PR DESCRIPTION
Use `app.process(delete_from_history=True)` to allow app deleting result from Gigapixel history.

If `delete_from_history=True`, this button will be pressed after process.

![image](https://user-images.githubusercontent.com/44952199/228207766-bc61bf64-b81a-4ca1-8ff2-f3e69a33d183.png)

Closes #5