### PR TITLE
Add High Quality mode from Gigapixel 6.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Requirements
 
-[Topaz Gigapixel AI](https://www.topazlabs.com/gigapixel-ai) **v6** of **newer** required
+[Topaz Gigapixel AI](https://www.topazlabs.com/gigapixel-ai) **v6.3.3** or **newer** required
 
 ## Installation
 

--- a/gigapixel/gigapixel.py
+++ b/gigapixel/gigapixel.py
@@ -24,7 +24,8 @@ class Mode(Enum):
     STANDARD = "Standard"
     Lines = "Lines"
     ART_AND_CG = "Art & CG"
-    LOW_RESOLUTION = "Low Resolution"
+    HIGH_QUALITY = "HQ"
+    LOW_RESOLUTION = "Low Res"
     VERY_COMPRESSED = "Very Compressed"
 
 


### PR DESCRIPTION
New mode add to app: `Mode.HIGH_QUALITY`
Gigapixel 6.3.3 now required.
Closes #12.